### PR TITLE
fix: restore GA4 tracking (gtag stub must push arguments, not an array)

### DIFF
--- a/src/lib/gtag.ts
+++ b/src/lib/gtag.ts
@@ -6,8 +6,14 @@ export const initializeGoogleAnalytics = () => {
   if (typeof window === 'undefined') return;
   window.dataLayer ??= [];
   if (!window.gtag) {
-    window.gtag = ((...args: unknown[]) =>
-      window.dataLayer?.push(args)) as Window['gtag'];
+    // gtag.js consumes dataLayer entries as native `arguments` objects.
+    // Pushing a spread array instead makes GA4 silently drop every command
+    // (no beacons are sent), so the stub must forward `arguments` as-is.
+    const gtag: Window['gtag'] = function () {
+      // biome-ignore lint/complexity/noArguments: gtag stub must push the native `arguments`
+      window.dataLayer?.push(arguments);
+    };
+    window.gtag = gtag;
     window.gtag('js', new Date());
     window.gtag('config', GOOGLE_ANALYTICS_ID, { send_page_view: false });
   }


### PR DESCRIPTION
## 概要 / What
Google Analytics のページビュー計測が止まっていた不具合を修正します。

## 原因 / Why
App Router 移行の #20 で導入された gtag スタブが、アロー関数 + スプレッドで **配列** を dataLayer に push していました。

```js
// Before (broken)
window.gtag = ((...args) => window.dataLayer?.push(args)) as Window['gtag'];
```

gtag.js は dataLayer のエントリを **ネイティブの arguments オブジェクト** として処理する前提のため、配列を渡すと js / config / page_view コマンドがすべて無視され、GA4 のビーコンが一切送信されません。コンソールにエラーも出ないサイレント失敗のため、「いつの間にか計測できなくなっていた」症状に一致します。

## 変更 / What changed
Google 公式スニペットと同じく、通常関数で arguments をそのまま push するように修正しました。

```js
// After
const gtag: Window['gtag'] = function () {
  window.dataLayer?.push(arguments);
};
```

- 変更ファイル: src/lib/gtag.ts の 1 箇所のみ
- 測定ID G-PJBP94L671、send_page_view: false + 手動 page_view 送信（SPA 向けの正しいパターン）はいずれも適切だったため変更なし

## 検証 / How verified
pnpm dev 起動後、ブラウザで実機確認:
- dataLayer の各エントリが arguments オブジェクトになった（修正前は配列 → 破棄）
- gtag.js がキューを正常に処理
- 実際に GA4 の collect ビーコンが送信された: analytics.google.com/g/collect?...tid=G-PJBP94L671...&en=page_view
- tsc --noEmit / biome lint ともにパス（残る any 警告は無関係な既存箇所）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
