### PR TITLE
Fix markdown list markers

### DIFF
--- a/src/styles/gtihub-markdown.css
+++ b/src/styles/gtihub-markdown.css
@@ -22,6 +22,18 @@
   list-style-type: decimal;
 }
 
+.markdown-body ul {
+  list-style-type: disc;
+}
+
+.markdown-body ul ul {
+  list-style-type: circle;
+}
+
+.markdown-body ul ul ul {
+  list-style-type: square;
+}
+
 .markdown-body ol[type="a"] {
   list-style-type: lower-alpha;
 }
@@ -40,6 +52,10 @@
 
 .markdown-body li {
   list-style-type: inherit;
+}
+
+.markdown-body li::marker {
+  color: var(--primary);
 }
 
 .markdown-body h1:hover .anchor .octicon-link:before,


### PR DESCRIPTION
## 概要

記事詳細ページのMarkdown本文で、箇条書きの「・」が表示されない問題を修正します。

## 変更内容

- `ul` のマーカーを `disc` に設定
- ネストしたリストに `circle` / `square` を設定
- `li` のマーカー色をアクセントカラーに統一

## 原因

Tailwind CSSのリセットでリストマーカーが無効化されている一方、記事用CSSでは `ol` のスタイルだけが復元されており、`ul` のマーカー指定がありませんでした。

## 検証

- TypeScript型チェック: 成功
- Next.js Webpack本番ビルド: 成功
- `git diff --check`: 成功
